### PR TITLE
Implement content tags 🏷 for `/thoughts` posts

### DIFF
--- a/posts/thoughts/on-abstraction.md
+++ b/posts/thoughts/on-abstraction.md
@@ -5,6 +5,8 @@ tldr: concept of abstraction and learning to code.
 tag: work
 ---
 
+*Note: this entry was written regarding the [earlier version](https://jinyoungch0i.github.io) of this blog*
+
 The idea of things being abstracted away is at the core of how we make sense and interact with the world around us. 
 
 For example, if I were to turn on the TV in my parent's livingroom (which I certainly find myself doing a lot during this indefinite quarantine), I wouldn't exactly 'hack' into the hardware of the television just to manipulate it to flip on the channel I want to view; that would be rather inefficient and would instead push me towards a less cognitively-demanding pastime. 

--- a/posts/thoughts/on-abstraction.md
+++ b/posts/thoughts/on-abstraction.md
@@ -2,7 +2,7 @@
 title: on abstraction
 date: sep 18 2020
 tldr: concept of abstraction and learning to code.
-tag: work
+tag: career
 ---
 
 *Note: this entry was written regarding the [earlier version](https://jinyoungch0i.github.io) of this blog*

--- a/posts/thoughts/on-abstraction.md
+++ b/posts/thoughts/on-abstraction.md
@@ -2,9 +2,8 @@
 title: on abstraction
 date: sep 18 2020
 tldr: concept of abstraction and learning to code.
+tag: work
 ---
-
-*Note: this entry was written regarding the [earlier version](https://jinyoungch0i.github.io) of this blog*
 
 The idea of things being abstracted away is at the core of how we make sense and interact with the world around us. 
 

--- a/posts/thoughts/on-application.md
+++ b/posts/thoughts/on-application.md
@@ -2,7 +2,7 @@
 title: on application
 date: nov 08 2020
 tldr: putting knowledge into practice.
-tag: work
+tag: career
 ---
 
 *Note: this entry was written regarding the [earlier version](https://jinyoungch0i.github.io) of this blog*

--- a/posts/thoughts/on-application.md
+++ b/posts/thoughts/on-application.md
@@ -2,6 +2,7 @@
 title: on application
 date: nov 08 2020
 tldr: putting knowledge into practice.
+tag: work
 ---
 
 *Note: this entry was written regarding the [earlier version](https://jinyoungch0i.github.io) of this blog*

--- a/posts/thoughts/on-building.md
+++ b/posts/thoughts/on-building.md
@@ -2,7 +2,7 @@
 title: on building
 date: sep 16 2020
 tldr: console.log('hello world')
-tag: work
+tag: career
 ---
 
 *Note: this entry was written regarding the [earlier version](https://jinyoungch0i.github.io) of this blog*

--- a/posts/thoughts/on-building.md
+++ b/posts/thoughts/on-building.md
@@ -2,6 +2,7 @@
 title: on building
 date: sep 16 2020
 tldr: console.log('hello world')
+tag: work
 ---
 
 *Note: this entry was written regarding the [earlier version](https://jinyoungch0i.github.io) of this blog*

--- a/posts/thoughts/on-craftmanship.md
+++ b/posts/thoughts/on-craftmanship.md
@@ -2,7 +2,7 @@
 title: on craftmanship
 date: sep 17 2020
 tldr: programming as a craft.
-tag: work
+tag: career
 ---
 
 *Note: this entry was written regarding the [earlier version](https://jinyoungch0i.github.io) of this blog*

--- a/posts/thoughts/on-craftmanship.md
+++ b/posts/thoughts/on-craftmanship.md
@@ -1,7 +1,8 @@
 ---
 title: on craftmanship
 date: sep 17 2020
-tldr: programming as a craft. 
+tldr: programming as a craft.
+tag: work
 ---
 
 *Note: this entry was written regarding the [earlier version](https://jinyoungch0i.github.io) of this blog*

--- a/posts/thoughts/on-direction.md
+++ b/posts/thoughts/on-direction.md
@@ -2,6 +2,7 @@
 title: on direction
 date: oct 11 2020
 tldr: self-teaching and unlearning.
+tag: work
 ---
 
 I'm confident that self-guided learning is something I am willing to remain committed to, at least for now. 

--- a/posts/thoughts/on-direction.md
+++ b/posts/thoughts/on-direction.md
@@ -2,7 +2,7 @@
 title: on direction
 date: oct 11 2020
 tldr: self-teaching and unlearning.
-tag: work
+tag: career
 ---
 
 I'm confident that self-guided learning is something I am willing to remain committed to, at least for now. 

--- a/posts/thoughts/on-growth.md
+++ b/posts/thoughts/on-growth.md
@@ -2,7 +2,7 @@
 title: on growth
 date: oct 03 2022
 tldr: navigating on-the-job learning.
-tag: work
+tag: career
 ---
 
 I have found myself navigating through a fair amount of career-related life changes since my last [/thoughts](../thoughts) entry.

--- a/posts/thoughts/on-growth.md
+++ b/posts/thoughts/on-growth.md
@@ -2,6 +2,7 @@
 title: on growth
 date: oct 03 2022
 tldr: navigating on-the-job learning.
+tag: work
 ---
 
 I have found myself navigating through a fair amount of career-related life changes since my last [/thoughts](../thoughts) entry.

--- a/posts/thoughts/on-iteration.md
+++ b/posts/thoughts/on-iteration.md
@@ -2,7 +2,7 @@
 title: on iteration
 date: feb 27 2021
 tldr: career development and its iterative nature.
-tag: work
+tag: career
 ---
 
 Software engineering is all about iteration upon iteration.

--- a/posts/thoughts/on-iteration.md
+++ b/posts/thoughts/on-iteration.md
@@ -2,6 +2,7 @@
 title: on iteration
 date: feb 27 2021
 tldr: career development and its iterative nature.
+tag: work
 ---
 
 Software engineering is all about iteration upon iteration.

--- a/posts/thoughts/on-minimalism.md
+++ b/posts/thoughts/on-minimalism.md
@@ -2,6 +2,7 @@
 title: on minimalism
 date: sep 20 2020
 tldr: applying minimalism to building on the web.
+tag: personal
 ---
 
 *Note: this entry was written regarding the [earlier version](https://jinyoungch0i.github.io) of this blog*

--- a/posts/thoughts/on-minimalism.md
+++ b/posts/thoughts/on-minimalism.md
@@ -2,7 +2,7 @@
 title: on minimalism
 date: sep 20 2020
 tldr: applying minimalism to building on the web.
-tag: personal
+tag: career
 ---
 
 *Note: this entry was written regarding the [earlier version](https://jinyoungch0i.github.io) of this blog*

--- a/posts/thoughts/on-multilingualism.md
+++ b/posts/thoughts/on-multilingualism.md
@@ -2,6 +2,7 @@
 title: on multilingualism
 date: sep 25 2020
 tldr: overlaps in programming and multilingualism.
+tag: work
 ---
 
 Some friends of mine remarked that I wouldn't necessarily have a hard time picking up computer programming because of my proficiency in four human languages. 

--- a/posts/thoughts/on-multilingualism.md
+++ b/posts/thoughts/on-multilingualism.md
@@ -2,7 +2,7 @@
 title: on multilingualism
 date: sep 25 2020
 tldr: overlaps in programming and multilingualism.
-tag: work
+tag: career
 ---
 
 Some friends of mine remarked that I wouldn't necessarily have a hard time picking up computer programming because of my proficiency in four human languages. 

--- a/posts/thoughts/on-patience.md
+++ b/posts/thoughts/on-patience.md
@@ -2,6 +2,7 @@
 title: on patience
 date: oct 23 2020
 tldr: learning javascript for the first time.
+tag: work
 ---
 
 I've been struggling to write this entry because my mind has been overwhelmingly conflicted this past week. 

--- a/posts/thoughts/on-patience.md
+++ b/posts/thoughts/on-patience.md
@@ -2,7 +2,7 @@
 title: on patience
 date: oct 23 2020
 tldr: learning javascript for the first time.
-tag: work
+tag: career
 ---
 
 I've been struggling to write this entry because my mind has been overwhelmingly conflicted this past week. 

--- a/posts/thoughts/on-reconnecting.md
+++ b/posts/thoughts/on-reconnecting.md
@@ -2,6 +2,7 @@
 title: on reconnecting
 date: oct 5 2020
 tldr: belonging and self-identity in the appalachians.
+tag: personal
 ---
 
 I've finally settled down, after having been on the move for the past year and a half. 

--- a/src/components/post/post.tsx
+++ b/src/components/post/post.tsx
@@ -7,6 +7,7 @@ import styles from './post.module.css';
 
 export default function Post({
   title = '',
+  tag='',
   date = '',
   isThoughtsEntry = false,
   isCodeEntry = false,
@@ -18,11 +19,15 @@ export default function Post({
   projectSummary = ''
 }) {
 
-  let hackathonUrl;
-  let hackathonName;
-
-  if (hackathon) {
-    [hackathonName, hackathonUrl] = hackathon.split(" ")
+  const postTagBackgroundGenerator = (tag) => {
+    switch (tag) {
+      case 'work':
+        return 'thoughtsPostCareerTag'
+      case 'personal':
+        return 'thoughtsPostPersonalTag'
+      default:
+        break;
+    } (tag === '')
   }
 
   return (
@@ -38,9 +43,14 @@ export default function Post({
                 <h2>{title}<kbd> ↵</kbd></h2>
               </a>
             ): (
+            <div className='thoughtsPostTitleAndTag'>
               <a>
-              <h2>{title}</h2>
-            </a>
+                <h2>{title}</h2>
+              </a>
+              <a>
+                <code className={postTagBackgroundGenerator(tag)}>{tag}</code>
+              </a>
+            </div>  
             )}
           </Link>
         ) : (

--- a/src/components/post/post.tsx
+++ b/src/components/post/post.tsx
@@ -21,7 +21,7 @@ export default function Post({
 
   const postTagBackgroundGenerator = (tag) => {
     switch (tag) {
-      case 'work':
+      case 'career':
         return 'thoughtsPostCareerTag'
       case 'personal':
         return 'thoughtsPostPersonalTag'

--- a/src/pages/thoughts/[slug].jsx
+++ b/src/pages/thoughts/[slug].jsx
@@ -9,10 +9,10 @@ const readingTime = require('reading-time');
 import { Layout, Post } from '../../components';
 
 
-export default function ThoughtsPage({ title = '', date = '', body = '', readingMins = 0, }) {
+export default function ThoughtsPage({ title = '', date = '', body = '', readingMins = 0, tag=''}) {
   return (
     <Layout siteTitle={title} pageTitle="thoughts">
-      <Post title={title} date={date} readingMins={readingMins}> 
+      <Post title={title} date={date} readingMins={readingMins} tag={tag}> 
         {body}
       </Post>
       <p className='return-to-main'>
@@ -27,7 +27,7 @@ export async function getStaticProps({ ...ctx }) {
   const content = await import(`../../../posts/thoughts/${slug}.md`);
   const converter = new Converter({ metadata: true, extensions: [showdownHighlight] });
   const body = converter.makeHtml(content.default);
-  const { title, date } = converter.getMetadata();
+  const { title, date, tag } = converter.getMetadata();
 
   const { minutes } = readingTime(body);
   const readingMins = Math.round(minutes);
@@ -39,6 +39,7 @@ export async function getStaticProps({ ...ctx }) {
       date,
       body,
       readingMins,
+      tag
     },
   };
 }

--- a/src/pages/thoughts/index.jsx
+++ b/src/pages/thoughts/index.jsx
@@ -6,8 +6,8 @@ const readingTime = require('reading-time');
 export default function ThoughtsRouteIndexPage({ posts = [] }) {
   return (
     <Layout siteTitle="jinyoung / thoughts" pageTitle="thoughts">
-      {posts.map(({ title, date, tldr, slug, readingMins }) => (
-        <Post key={slug} title={title} date={date} slug={slug} readingMins={readingMins} isThoughtsEntry>
+      {posts.map(({ title, tag, date, tldr, slug, readingMins }) => (
+        <Post key={slug} tag={tag} title={title} date={date} slug={slug} readingMins={readingMins} isThoughtsEntry>
           {tldr}
         </Post>
       ))}
@@ -26,18 +26,19 @@ export async function getStaticProps() {
       const content = values[index];
       const converter = new Converter({ metadata: true });
       const body = converter.makeHtml(content.default);
-      const { title, date, tldr } = converter.getMetadata();
+      const { title, date, tldr, tag } = converter.getMetadata();
 
       const { minutes } = readingTime(body);
       const readingMins = Math.round(minutes);
       console.log(`reading time for [${title}]:`, `${readingMins}mins`)
 
       return {
-        title,
+        tag,
         date,
-        tldr,
+        readingMins,
         slug,
-        readingMins
+        title,
+        tldr,
       };
     });
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,13 +7,13 @@
   --black: #111;
   --black-grey: #222;
   --grey: #716a66;
-  --maroon: #7b3636;
   --foreground: var(--black);
   --midground: var(--black-grey);
   --background: var(--white);
   --linkedin: #00b9ff;
   --babbel: #ff6f21;
   --thoughts: #cdd327;
+  --github: #5862b1;
   --personal: #373e72;
   --work: #4e2626;
   --email: #8154a2;
@@ -154,7 +154,7 @@ blockquote {
 
 .github,
 .github::selection {
-  text-decoration-color: var(--work);
+  text-decoration-color: var(--github);
 }
 
 .email,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,13 +7,15 @@
   --black: #111;
   --black-grey: #222;
   --grey: #716a66;
+  --maroon: #7b3636;
   --foreground: var(--black);
   --midground: var(--black-grey);
   --background: var(--white);
   --linkedin: #00b9ff;
   --babbel: #ff6f21;
   --thoughts: #cdd327;
-  --github: #5862b1;
+  --personal: #373e72;
+  --work: #4e2626;
   --email: #8154a2;
   --dev: rgb(72, 167, 0);
   --transition:
@@ -152,7 +154,7 @@ blockquote {
 
 .github,
 .github::selection {
-  text-decoration-color: var(--github);
+  text-decoration-color: var(--work);
 }
 
 .email,
@@ -187,6 +189,22 @@ blockquote {
 
 #code-page-description {
   font-size: 1.15rem;
+}
+
+.thoughtsPostTitleAndTag {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.thoughtsPostCareerTag {
+  background-color: var(--work);
+  color: var(--white);
+}
+
+.thoughtsPostPersonalTag {
+  background-color: var(--personal);
+  color: var(--white);
 }
 
 @media only screen and (max-width: 500px) {


### PR DESCRIPTION
Available tags as of current: `career` and `personal`.

Note to self: 
- Next step in the `Todo` is to allow filtering/sorting based on tags from within the `ThoughtsIndexPage`.
  - (this is why the tag UI is an `<a></a>`; so that this feature could be further worked on.
  - the filtering/sorting could take form of clickable tags or a summary blurb:
    - eg. `filter: all | career | personal`
- Also worth noting that tags could be further segmented; `career` and `personal` are quite vague, and specificity could certainly be introduced at a later date for more helpful/descriptive tags 🙂
- Also (x2) the `hackathon` tag for `/code` projects might benefit from a styling retouch to sync with the `var(--dev)` of the hyperlink arrow on project title ✅
- Lastly, tags are not displaying on the individual `posts/` entry route; this could be worked on or left as is 👌🏼